### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ lto = true
 [dependencies]
 libm = "0.2"
 log = "0.4"
-spin = "0.9"
+spin = "0.9.8"
 
 [dev-dependencies]
 simple_logger = "2.1"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)